### PR TITLE
#236 [BAPI] Allow freeze only on future voting start

### DIFF
--- a/apps/backend/src/middlewares/pathParamChecks/electionChecks.ts
+++ b/apps/backend/src/middlewares/pathParamChecks/electionChecks.ts
@@ -169,6 +169,39 @@ export async function checkElectionNotGenerateKeys(
   }
 }
 
+/**
+ * Checks if the voting start date of the election with the given ID is in the future.
+ * If the voting start date is in the past, it sends a 403 Forbidden response.
+ * If the voting start date is in the future, it calls the next middleware function.
+ *
+ * @param req The request object containing the election ID as a path parameter.
+ * @param res The response object to send errors to.
+ * @param next The next middleware function to call if the election is not frozen.
+ */
+export async function checkVotingStartInFuture(
+  req: Request<{ electionId: Election['id'] }>,
+  res: Response<Response403>,
+  next: NextFunction,
+): Promise<void> {
+  const result = await db
+    .selectFrom('election')
+    .select(['id', 'votingStartAt'])
+    .where('id', '=', req.params.electionId)
+    .executeTakeFirstOrThrow();
+
+  if (result.votingStartAt < new Date()) {
+    res.status(HttpStatusCode.forbidden).json(
+      response403Object.parse({
+        message:
+          'The voting start date is the past. ' +
+          'You are only allowed to do this action if the voting start date is in the future.',
+      }),
+    );
+  } else {
+    next();
+  }
+}
+
 export const defaultElectionChecks = [
   checkElectionUuid,
   checkElectionExists,

--- a/apps/backend/src/middlewares/pathParamChecks/electionChecks.ts
+++ b/apps/backend/src/middlewares/pathParamChecks/electionChecks.ts
@@ -109,22 +109,16 @@ export async function checkUserOwnerOfElection(
  */
 export async function checkElectionNotFrozen(
   req: Request<{ electionId: Election['id'] }>,
-  res: Response<Response403 | Response404>,
+  res: Response<Response403>,
   next: NextFunction,
 ): Promise<void> {
   const result = await db
     .selectFrom('election')
     .select(['id', 'configFrozen'])
     .where('id', '=', req.params.electionId)
-    .executeTakeFirst();
+    .executeTakeFirstOrThrow();
 
-  if (result === undefined) {
-    res.status(HttpStatusCode.notFound).json(
-      response404Object.parse({
-        message: 'The provided election does not exist!',
-      }),
-    );
-  } else if (result.configFrozen) {
+  if (result.configFrozen) {
     res.status(HttpStatusCode.forbidden).json(
       response403Object.parse({
         message: 'The election is frozen and cannot be modified.',

--- a/apps/backend/src/routes/elections.routes.ts
+++ b/apps/backend/src/routes/elections.routes.ts
@@ -46,6 +46,7 @@ import {
 import {
   checkElectionNotFrozen,
   checkElectionNotGenerateKeys,
+  checkVotingStartInFuture,
   defaultElectionChecks,
 } from '../middlewares/pathParamChecks/electionChecks.js';
 import { MimeType } from '../middlewares/utils.js';
@@ -78,6 +79,7 @@ electionsRouter.put(
   `/:${parameter.electionId}/freeze`,
   acceptHeaderCheck(MimeType.applicationJson),
   ...defaultElectionChecks,
+  checkVotingStartInFuture,
   checkElectionNotFrozen,
   freezeElection,
 );

--- a/apps/backend/test/elections/freezeElection.test.ts
+++ b/apps/backend/test/elections/freezeElection.test.ts
@@ -11,12 +11,13 @@ import { app } from '../../src/app.js';
 import { generateUserTokens } from '../../src/auth/utils.js';
 import { HttpStatusCode } from '../../src/httpStatusCode.js';
 import { createUser, findUserBy } from '../../src/services/users.service.js';
-import { demoElection, demoUser } from '../mockData.js';
+import { demoElection, demoUser, pastElection } from '../mockData.js';
 import { sleep } from '../utils.js';
 import { createElection } from './../../src/services/elections.service.js';
 
 describe(`PUT /elections/:${parameter.electionId}/freeze`, () => {
   let requestPath = '';
+  let pastElectionRequestPath = '';
   let election: SelectableElection | null = null;
   let tokens: ApiTokenUser = { accessToken: '', refreshToken: '' };
 
@@ -28,8 +29,10 @@ describe(`PUT /elections/:${parameter.electionId}/freeze`, () => {
     }
 
     election = await createElection(demoElection, user.id);
+    const election2 = await createElection(pastElection, user.id);
 
     requestPath = `/elections/${election.id}/freeze`;
+    pastElectionRequestPath = `/elections/${election2.id}/freeze`;
 
     tokens = generateUserTokens(user.id);
   });
@@ -62,6 +65,15 @@ describe(`PUT /elections/:${parameter.electionId}/freeze`, () => {
   it('403: should not allow freezing a second time', async () => {
     const res = await request(app)
       .put(requestPath)
+      .set('Authorization', `Bearer ${tokens.accessToken}`);
+    expect(res.status).toBe(HttpStatusCode.forbidden);
+    expect(res.type).toBe('application/json');
+    const parseResult = response403Object.safeParse(res.body);
+    expect(parseResult.success).toBe(true);
+  });
+  it('403: should not allow freezing a past election', async () => {
+    const res = await request(app)
+      .put(pastElectionRequestPath)
       .set('Authorization', `Bearer ${tokens.accessToken}`);
     expect(res.status).toBe(HttpStatusCode.forbidden);
     expect(res.type).toBe('application/json');

--- a/apps/backend/test/mockData.ts
+++ b/apps/backend/test/mockData.ts
@@ -25,16 +25,16 @@ export const demoUser2 = insertableUserObject.parse({
 export const demoElection = insertableElectionObject.parse({
   name: 'My test election',
   private: true,
-  votingStartAt: '2025-06-16T14:30:00Z',
-  votingEndAt: '2025-06-18T14:30:00Z',
+  votingStartAt: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+  votingEndAt: new Date(Date.now() + 10 * 60 * 60 * 1000).toISOString(),
   allowInvalidVotes: false,
 });
 export const demoElection2 = insertableElectionObject.parse({
   name: 'My test election 2',
   description: 'My test election description 2',
   private: true,
-  votingStartAt: '2026-06-16T14:30:00Z',
-  votingEndAt: '2026-06-18T14:30:00Z',
+  votingStartAt: new Date(Date.now() + 1 * 60 * 60 * 1000).toISOString(),
+  votingEndAt: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
   allowInvalidVotes: false,
 });
 export const brokenElection = {
@@ -44,6 +44,14 @@ export const brokenElection = {
   votingEndAt: '2025-06-16T14:30:00Z',
   allowInvalidVotes: 'false',
 };
+export const pastElection = insertableElectionObject.parse({
+  name: 'My past election',
+  description: 'My past election description 2',
+  private: true,
+  votingStartAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+  votingEndAt: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString(),
+  allowInvalidVotes: false,
+});
 
 /*
  * Ballot papers


### PR DESCRIPTION
# Changes

Resolves #236 

This pr implements that only elections can be frozen when the voting start date is in the future.