### PR TITLE
fix: correct typo Invalid voted allowed -> Invalid votes allowed

### DIFF
--- a/apps/frontend/src/components/views/election/ElectionStats.tsx
+++ b/apps/frontend/src/components/views/election/ElectionStats.tsx
@@ -30,7 +30,7 @@ export const ElectionStats = ({ election }: ElectionStatsProps): JSX.Element => 
       </Grid.Col>
       <Grid.Col span={3}>
         <ElectionStatField
-          title={'Invalid voted allowed'}
+          title={'Invalid votes allowed'}
           content={<BooleanBadge isTrue={election.allowInvalidVotes} />}
         />
       </Grid.Col>


### PR DESCRIPTION
Fixed grammatical typo in ElectionStats.tsx:

- Before: Invalid voted allowed
- After: Invalid votes allowed

Closes #367