### PR TITLE
#363: Bump @mantine packages from 8.3.3 to 8.3.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6740,9 +6740,10 @@
       }
     },
     "node_modules/@mantine/core": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.3.3.tgz",
-      "integrity": "sha512-OdTAQ0lsXjEqfea0KyXJ1rV9cZb/Rtqv5l3luG2m8Sx5BTGMqXas6mKHtdj4LwIiUKeFkIkZYjNmH6ri1HXjSA==",
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.3.18.tgz",
+      "integrity": "sha512-9tph1lTVogKPjTx02eUxDUOdXacPzK62UuSqb4TdGliI54/Xgxftq0Dfqu6XuhCxn9J5MDJaNiLDvL/1KRkYqA==",
+      "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
         "clsx": "^2.1.1",
@@ -6752,30 +6753,32 @@
         "type-fest": "^4.41.0"
       },
       "peerDependencies": {
-        "@mantine/hooks": "8.3.3",
+        "@mantine/hooks": "8.3.18",
         "react": "^18.x || ^19.x",
         "react-dom": "^18.x || ^19.x"
       }
     },
     "node_modules/@mantine/dates": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/@mantine/dates/-/dates-8.3.3.tgz",
-      "integrity": "sha512-eJjXXFiUDuRkZE3f0AJNSUjWAc5sjkjEYwWquxkKOdSDtd+6vzKp5Yo2AlCvcrb3XoocNFSb79w5tGmS6XYn8g==",
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@mantine/dates/-/dates-8.3.18.tgz",
+      "integrity": "sha512-FHx5teJOhupI0gO2o5evtVYQEdqOjayOkLRhEQfB5Nc5DvcysfPfmNILGkc1Nrp9ZQeQWKLT9qr+CkcCXwHOaw==",
+      "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.1"
       },
       "peerDependencies": {
-        "@mantine/core": "8.3.3",
-        "@mantine/hooks": "8.3.3",
+        "@mantine/core": "8.3.18",
+        "@mantine/hooks": "8.3.18",
         "dayjs": ">=1.0.0",
         "react": "^18.x || ^19.x",
         "react-dom": "^18.x || ^19.x"
       }
     },
     "node_modules/@mantine/form": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/@mantine/form/-/form-8.3.3.tgz",
-      "integrity": "sha512-KMPjW76Ri6zHstD+/U/PCo75NAhq/6dKuz6LjeetJCQ1et1HuiCVZ4Evi2OZuqK85aOE/e3B1c7ekulSrhcj8A==",
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@mantine/form/-/form-8.3.18.tgz",
+      "integrity": "sha512-r5OGLJWTkmIruFjRZRZy9oA7maNYlyt50jB4Pmd2X5360WOmJLd4KH8MFhHZQC7vN+z8/rmBl3t3XGAR2I8xig==",
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "klona": "^2.0.6"
@@ -6785,32 +6788,35 @@
       }
     },
     "node_modules/@mantine/hooks": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-8.3.3.tgz",
-      "integrity": "sha512-nmspxbFSjFkimRXYhgAujnyBwGeAWDSP1WKHFR+Yl5x3Q0IkmsiOTE9yJPjMjmjffZfunFXQFwQDl1OF3m42Pw==",
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-8.3.18.tgz",
+      "integrity": "sha512-QoWr9+S8gg5050TQ06aTSxtlpGjYOpIllRbjYYXlRvZeTsUqiTbVfvQROLexu4rEaK+yy9Wwriwl9PMRgbLqPw==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "^18.x || ^19.x"
       }
     },
     "node_modules/@mantine/notifications": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-8.3.3.tgz",
-      "integrity": "sha512-tEp2nGxx9gd8616V7T93l6D6XAXmEa+H2MERwxsBs6IGjGcswda8MUc10SLhLCJgDzB0RX0Pcod4r+tpGbXz/Q==",
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-8.3.18.tgz",
+      "integrity": "sha512-IpQ0lmwbigTBbZCR6iSYWqIOKEx1tlcd7PcEJ5M5X1qeVSY/N3mmDQt1eJmObvcyDeL5cTJMbSA9UPqhRqo9jw==",
+      "license": "MIT",
       "dependencies": {
-        "@mantine/store": "8.3.3",
+        "@mantine/store": "8.3.18",
         "react-transition-group": "4.4.5"
       },
       "peerDependencies": {
-        "@mantine/core": "8.3.3",
-        "@mantine/hooks": "8.3.3",
+        "@mantine/core": "8.3.18",
+        "@mantine/hooks": "8.3.18",
         "react": "^18.x || ^19.x",
         "react-dom": "^18.x || ^19.x"
       }
     },
     "node_modules/@mantine/store": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/@mantine/store/-/store-8.3.3.tgz",
-      "integrity": "sha512-+qUS0Dmww/M7ieA9lJbhKmagislVoWVUJam2DjTzvW3bJ311t1sAsu6G59I3YDN8avC2gRcipglZSRsInwzJVg==",
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@mantine/store/-/store-8.3.18.tgz",
+      "integrity": "sha512-i+QRTLmZzLldea0egtUVnGALd6UMIu8jd44nrNWBSNIXJU/8B6rMlC6gyX+l4szopZSuOaaNJIXkqRdC1gQsVg==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "^18.x || ^19.x"
       }
@@ -14430,19 +14436,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/docusaurus-plugin-sass": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/docusaurus-plugin-sass/-/docusaurus-plugin-sass-0.2.6.tgz",
-      "integrity": "sha512-2hKQQDkrufMong9upKoG/kSHJhuwd+FA3iAe/qzS/BmWpbIpe7XKmq5wlz4J5CJaOPu4x+iDJbgAxZqcoQf0kg==",
-      "peer": true,
-      "dependencies": {
-        "sass-loader": "^16.0.2"
-      },
-      "peerDependencies": {
-        "@docusaurus/core": "^2.0.0-beta || ^3.0.0-alpha",
-        "sass": "^1.30.0"
       }
     },
     "node_modules/docusaurus-theme-openapi-docs": {
@@ -28490,12 +28483,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
-    "node_modules/search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "peer": true
-    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -30623,7 +30610,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
Resolves #363

Bumps `@mantine/dates` and related `@mantine/*` packages from `8.3.3` to `8.3.18`.

## Checklist during development

- [x] I have read the [contributing guidelines](https://github.com/SE-UUlm/votura/blob/main/.github/CONTRIBUTING.md)
- [x] Followed the branch naming convention.
- [x] Marked the PR as a draft.
- [x] Added my self as an assignee.
- [x] Added the corresponding labels.
- [x] Linked the corresponding issue.
- [x] Added the votura project with status to `Under Development`, priority, sprint, start date and REQ level (identical to issue).
- [x] Added the milestone.
- [x] Only used signed commits.
- [x] Followed the commit message pattern.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] The pipeline is passing (code coverage, tests, static code analysis, ...).
- [x] I have resolved all merge conflicts.
- [x] If you are ready for review, please mark the PR as ready for review (remove the Draft) and set the status from `Under Development` to `To Review`.