### PR TITLE
#381: Fix failing Lint, Build & Test pipeline

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,7 +11,10 @@ jobs:
     runs-on:
       labels: ubuntu-latest
     container:
-      image: ubuntu:24.04
+      image: mcr.microsoft.com/playwright:v1.56.0-noble
+      env:
+        DEBIAN_FRONTEND: noninteractive
+        PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
     continue-on-error: false
     timeout-minutes: 30
 
@@ -30,12 +33,17 @@ jobs:
           node-version-file: package.json
           cache: npm
           cache-dependency-path: package-lock.json
+      - name: Remove yarn (conflicts with postman-code-generators postinstall)
+        run: |
+          corepack disable 2>/dev/null || true
+          while command -v yarn >/dev/null 2>&1; do
+            echo "removing $(command -v yarn)"
+            rm -f "$(command -v yarn)" "$(command -v yarnpkg)" 2>/dev/null || true
+            hash -r
+          done
+          command -v yarn >/dev/null 2>&1 && echo "WARNING: yarn still found at $(command -v yarn)" || echo "yarn fully removed"
       - name: Install npm dependencies
         run: npm ci
-      - name: Install Playwright Browsers
-        run: |
-          cd packages/e2e
-          npm run install-browsers
       - name: Generate .env file in backend
         run: |
           cd apps/backend

--- a/turbo.json
+++ b/turbo.json
@@ -80,7 +80,8 @@
         "HOME",
         "BITS_PRIME_P",
         "USERS_JWT_PRIV_KEY",
-        "USERS_JWT_PUB_KEY"
+        "USERS_JWT_PUB_KEY",
+        "PLAYWRIGHT_BROWSERS_PATH"
       ]
     },
     "start": {


### PR DESCRIPTION
# Changes

Resolves #381

This PR fixes the failing **Lint, Build & Test** workflow. `npx playwright install` hung at 100 % while downloading Chromium in the bare `ubuntu:24.04` container, so the job never reached the tests.

The job now runs on the official Playwright Docker image (browsers preinstalled, no download), pinned to `v1.56.0-noble` to match the installed `@playwright/test`. Two follow-up fixes this required:

- **Remove preinstalled yarn before `npm ci`** â€” the `postman-code-generators` postinstall detects yarn 1.22 and aborts on the repo's `packageManager` field.
- **Expose `PLAYWRIGHT_BROWSERS_PATH` through turbo's strict env mode** â€” so the e2e tests find the browsers baked into the image at `/ms-playwright`.

## Checklist during development

- [x] I have read the [contributing guidelines](https://github.com/SE-UUlm/votura/blob/main/.github/CONTRIBUTING.md)
- [x] Followed the branch naming convention.
- [x] Marked the PR as a draft.
- [x] Added my self as an assignee.
- [x] Added the corresponding labels.
- [x] Linked the corresponding issue.
- [x] Added the votura project with status to `Under Development`, priority, sprint, start date and REQ level (identical to issue).
- [ ] Added the milestone.
- [x] Only used signed commits.
- [x] Followed the commit message pattern.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] The pipeline is passing (code coverage, tests, static code analysis, ...).
- [x] I have resolved all merge conflicts.
- [x] If you are ready for review, please mark the PR as ready for review (remove the Draft) and set the status from `Under Development` to `To Review`.
