### PR TITLE
change image of deploy action to a node.j version 24

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -134,7 +134,7 @@ jobs:
     runs-on:
       labels: linux-sp
     container:
-      image: ubuntu:24.04
+      image: node:24
     continue-on-error: false
     timeout-minutes: 10
 


### PR DESCRIPTION
just a small update to use an image in the pipeline with node.js 24