### PR TITLE
#435: Load database migrations via file URLs

### DIFF
--- a/packages/db/src/migrateToLatest.ts
+++ b/packages/db/src/migrateToLatest.ts
@@ -1,17 +1,39 @@
 import { logger } from '@repo/logger';
 import { promises as fs } from 'fs';
-import { FileMigrationProvider, type Kysely, Migrator } from 'kysely';
+import { type Kysely, type Migration, type MigrationProvider, Migrator } from 'kysely';
 import path from 'path';
+import { pathToFileURL } from 'url';
+
+/**
+ * Drop-in replacement for kysely's FileMigrationProvider.
+ * FileMigrationProvider imports migration files by their plain absolute path, which the ESM
+ * loader rejects on Windows ("Received protocol 'c:'"). This provider imports the files via
+ * file:// URLs instead, which works on all platforms.
+ */
+const fileUrlMigrationProvider = (migrationFolder: string): MigrationProvider => ({
+  async getMigrations(): Promise<Record<string, Migration>> {
+    const migrations: Record<string, Migration> = {};
+
+    for (const fileName of (await fs.readdir(migrationFolder)).sort()) {
+      if (!fileName.endsWith('.ts') || fileName.endsWith('.d.ts')) {
+        continue;
+      }
+
+      const migration: unknown = await import(
+        pathToFileURL(path.join(migrationFolder, fileName)).href
+      );
+      migrations[fileName.substring(0, fileName.lastIndexOf('.'))] = migration as Migration;
+    }
+
+    return migrations;
+  },
+});
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const migrateToLatest = async (db: Kysely<any>, migrationFolder: string): Promise<void> => {
   const migrator = new Migrator({
     db,
-    provider: new FileMigrationProvider({
-      fs,
-      path,
-      migrationFolder: migrationFolder,
-    }),
+    provider: fileUrlMigrationProvider(migrationFolder),
   });
 
   const { error, results } = await migrator.migrateToLatest();


### PR DESCRIPTION
# Changes

Resolves #435

The backend test suite could not run on Windows. `vitest.setup.ts` calls `migrateToLatest`, which used kysely's `FileMigrationProvider`. That provider imports each migration file by its plain absolute path, and on Windows that path begins with a drive letter. Node's ESM loader rejects it with `ERR_UNSUPPORTED_ESM_URL_SCHEME: Received protocol 'c:'`, so the suite aborted during database setup. The CI runs on Linux, where absolute paths are accepted, so this was not visible in the pipeline.

This replaces `FileMigrationProvider` with a small provider that reads the migration directory and imports each file through a `file://` URL via `pathToFileURL`. Directory and file selection are unchanged, so migrations run exactly as before on Linux and macOS while also working on Windows.

This change was split out of #242, where the problem was first discovered while running the tests locally.

## Checklist during development

- [x] I have read the [contributing guidelines](https://github.com/SE-UUlm/votura/blob/main/.github/CONTRIBUTING.md)
- [x] Followed the branch naming convention.
- [x] Marked the PR as a draft.
- [x] Added my self as an assignee.
- [x] Added the corresponding labels.
- [x] Linked the corresponding issue.
- [x] Added the votura project with status to `Under Development`, priority, sprint, start date and REQ level (identical to issue).
- [ ] Added the milestone.
- [x] Only used signed commits.
- [x] Followed the commit message pattern.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] The pipeline is passing (code coverage, tests, static code analysis, ...).
- [ ] I have resolved all merge conflicts.
- [ ] If you are ready for review, please mark the PR as ready for review (remove the Draft) and set the status from `Under Development` to `To Review`.

> If you have checked all the boxes above, please remove this comment and the checklist above.
