### PR TITLE
Fix dependabot teamscale uploads

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -94,8 +94,8 @@ jobs:
         with:
           server: 'https://exia.informatik.uni-ulm.de/teamscale'
           project: 'b3ef710d-5a48-4918-9383-7381b21e45e2'
-          user: 'thorbencarl'
-          accesskey: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
+          user: 'jensostertag'
+          accesskey: ${{ secrets.TEAMSCALE_ACCESS_KEY_NEW }}
           partition: 'Github Action > ${{ github.ref_name }} ${{ github.run_id }}'
           format: CLOVER
           message: 'Code coverage from GitHub Actions'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -95,7 +95,7 @@ jobs:
           server: 'https://exia.informatik.uni-ulm.de/teamscale'
           project: 'b3ef710d-5a48-4918-9383-7381b21e45e2'
           user: 'jensostertag'
-          accesskey: ${{ secrets.TEAMSCALE_ACCESS_KEY_NEW }}
+          accesskey: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
           partition: 'Github Action > ${{ github.ref_name }} ${{ github.run_id }}'
           format: CLOVER
           message: 'Code coverage from GitHub Actions'


### PR DESCRIPTION
# Changes

Fixes the Teamscale uploads for dependabot PRs

- Generated new Teamscale access key (under my account name)
- Added a repository secret that dependabot should be able to access