### PR TITLE
User Roles

### DIFF
--- a/apps/backend/src/controllers/.bodyChecks/userChecks/loginRequest.check.ts
+++ b/apps/backend/src/controllers/.bodyChecks/userChecks/loginRequest.check.ts
@@ -1,6 +1,6 @@
 import { getPepper, verifyPassword } from '@repo/hash';
 import {
-  insertableUserObject,
+  authenticatableUserObject,
   zodErrorToResponse400,
   type Response429,
   type User,
@@ -68,7 +68,7 @@ export const validateLoginRequest = async (
   reqBody: unknown,
   ipAddress: string,
 ): Promise<User['id'] | LoginRequestValidationError> => {
-  const { data, error, success } = await insertableUserObject.safeParseAsync(reqBody);
+  const { data, error, success } = await authenticatableUserObject.safeParseAsync(reqBody);
   if (!success) {
     return {
       status: HttpStatusCode.badRequest,

--- a/apps/backend/src/controllers/users/createUser.uc.ts
+++ b/apps/backend/src/controllers/users/createUser.uc.ts
@@ -1,5 +1,5 @@
 import {
-  insertableUserObject,
+  authenticatableUserObject,
   response409Object,
   zodErrorToResponse400,
   type Response400,
@@ -14,7 +14,7 @@ export type CreateUserResponse = Response<void | Response400 | Response409>;
 export const createUser = async (req: Request, res: CreateUserResponse): Promise<void> => {
   const body: unknown = req.body;
 
-  const { data, error, success } = await insertableUserObject.safeParseAsync(body);
+  const { data, error, success } = await authenticatableUserObject.safeParseAsync(body);
 
   if (success) {
     // Check if a user with the provided email already exists
@@ -30,7 +30,7 @@ export const createUser = async (req: Request, res: CreateUserResponse): Promise
       return;
     }
 
-    await createPersistentUser(data);
+    await createPersistentUser({ ...data, role: 'user' });
 
     res.sendStatus(HttpStatusCode.noContent);
   } else {

--- a/apps/backend/src/services/users.service.ts
+++ b/apps/backend/src/services/users.service.ts
@@ -48,6 +48,7 @@ export async function findUserBy(
     createdAt: user.createdAt.toISOString(),
     modifiedAt: user.modifiedAt.toISOString(),
     email: user.email,
+    role: user.role,
   };
 }
 

--- a/apps/backend/src/services/users.service.ts
+++ b/apps/backend/src/services/users.service.ts
@@ -60,6 +60,7 @@ export async function createUser(insertableUser: InsertableUser): Promise<void> 
     .values({
       email: insertableUser.email,
       passwordHash: hashedPassword,
+      role: insertableUser.role,
     })
     .executeTakeFirstOrThrow();
 }

--- a/apps/backend/test/elections/getElection.test.ts
+++ b/apps/backend/test/elections/getElection.test.ts
@@ -25,6 +25,7 @@ describe('GET /elections/:electionId', () => {
     await createUser({
       email: 'user@votura.org',
       password: 'password',
+      role: 1,
     });
 
     user = await findUserBy({

--- a/apps/backend/test/elections/getElection.test.ts
+++ b/apps/backend/test/elections/getElection.test.ts
@@ -25,7 +25,7 @@ describe('GET /elections/:electionId', () => {
     await createUser({
       email: 'user@votura.org',
       password: 'password',
-      role: 1,
+      role: 'admin',
     });
 
     user = await findUserBy({

--- a/apps/backend/test/elections/getElections.test.ts
+++ b/apps/backend/test/elections/getElections.test.ts
@@ -19,6 +19,7 @@ describe('GET /elections', () => {
     await createUser({
       email: 'user@votura.org',
       password: 'password',
+      role: 1,
     });
 
     const user = await findUserBy({

--- a/apps/backend/test/elections/getElections.test.ts
+++ b/apps/backend/test/elections/getElections.test.ts
@@ -19,7 +19,7 @@ describe('GET /elections', () => {
     await createUser({
       email: 'user@votura.org',
       password: 'password',
-      role: 1,
+      role: 'admin',
     });
 
     const user = await findUserBy({

--- a/apps/backend/test/elections/postElections.test.ts
+++ b/apps/backend/test/elections/postElections.test.ts
@@ -29,7 +29,7 @@ describe('POST /elections', () => {
     await createUser({
       email: 'user@votura.org',
       password: 'password',
-      role: 1,
+      role: 'admin',
     });
 
     const user = await findUserBy({

--- a/apps/backend/test/elections/postElections.test.ts
+++ b/apps/backend/test/elections/postElections.test.ts
@@ -29,6 +29,7 @@ describe('POST /elections', () => {
     await createUser({
       email: 'user@votura.org',
       password: 'password',
+      role: 1,
     });
 
     const user = await findUserBy({

--- a/apps/backend/test/mockData.ts
+++ b/apps/backend/test/mockData.ts
@@ -14,12 +14,12 @@ const STRONG_PWD = 'MyStrong!Password123';
 export const demoUser = insertableUserObject.parse({
   email: 'user@votura.org',
   password: STRONG_PWD,
-  role: 1,
+  role: 'admin',
 });
 export const demoUser2 = insertableUserObject.parse({
   email: 'user2@votura.org',
   password: STRONG_PWD,
-  role: 0,
+  role: 'user',
 });
 
 /*

--- a/apps/backend/test/mockData.ts
+++ b/apps/backend/test/mockData.ts
@@ -14,10 +14,12 @@ const STRONG_PWD = 'MyStrong!Password123';
 export const demoUser = insertableUserObject.parse({
   email: 'user@votura.org',
   password: STRONG_PWD,
+  role: 1,
 });
 export const demoUser2 = insertableUserObject.parse({
   email: 'user2@votura.org',
   password: STRONG_PWD,
+  role: 0,
 });
 
 /*

--- a/apps/backend/test/users/createUser.test.ts
+++ b/apps/backend/test/users/createUser.test.ts
@@ -18,6 +18,7 @@ describe(`POST /users`, () => {
     const res = await request(app).post(requestPath).send({
       email: 'invalid-email',
       password: 'short',
+      role: 1,
     });
     expect(res.status).toBe(HttpStatusCode.badRequest);
     expect(res.type).toBe('application/json');

--- a/apps/backend/test/users/createUser.test.ts
+++ b/apps/backend/test/users/createUser.test.ts
@@ -18,7 +18,7 @@ describe(`POST /users`, () => {
     const res = await request(app).post(requestPath).send({
       email: 'invalid-email',
       password: 'short',
-      role: 1,
+      role: 'admin',
     });
     expect(res.status).toBe(HttpStatusCode.badRequest);
     expect(res.type).toBe('application/json');

--- a/apps/backend/test/users/loginUser.test.ts
+++ b/apps/backend/test/users/loginUser.test.ts
@@ -22,7 +22,7 @@ describe(`POST /users/login`, () => {
   });
 
   beforeAll(async () => {
-    await createUser({ ...loginUser, role: 1 });
+    await createUser({ ...loginUser, role: 'admin' });
     user = await findUserBy({ email: loginUser.email });
     if (user === null) {
       throw new Error('Failed to find test user');

--- a/apps/backend/test/users/loginUser.test.ts
+++ b/apps/backend/test/users/loginUser.test.ts
@@ -1,6 +1,6 @@
 import {
   apiTokenUserObject,
-  insertableUserObject,
+  authenticatableUserObject,
   response400Object,
   response401Object,
   response429Object,
@@ -16,14 +16,13 @@ describe(`POST /users/login`, () => {
   let requestPath = '';
   let user: SelectableUser | null = null;
   // create a test user only for this test to not have race conditions with token refresh tests
-  const loginUser = insertableUserObject.parse({
+  const loginUser = authenticatableUserObject.parse({
     email: 'loginUser@votura.org',
     password: 'MyStrong!Password123',
-    role: 1,
   });
 
   beforeAll(async () => {
-    await createUser(loginUser);
+    await createUser({ ...loginUser, role: 1 });
     user = await findUserBy({ email: loginUser.email });
     if (user === null) {
       throw new Error('Failed to find test user');

--- a/apps/backend/test/users/loginUser.test.ts
+++ b/apps/backend/test/users/loginUser.test.ts
@@ -19,6 +19,7 @@ describe(`POST /users/login`, () => {
   const loginUser = insertableUserObject.parse({
     email: 'loginUser@votura.org',
     password: 'MyStrong!Password123',
+    role: 1,
   });
 
   beforeAll(async () => {

--- a/apps/backend/test/users/refreshUserTokens.test.ts
+++ b/apps/backend/test/users/refreshUserTokens.test.ts
@@ -1,6 +1,6 @@
 import {
   apiTokenUserObject,
-  insertableUserObject,
+  authenticatableUserObject,
   response400Object,
   response401Object,
   type SelectableUser,
@@ -24,14 +24,13 @@ describe(`POST /users/refreshTokens`, () => {
   let user: SelectableUser | null = null;
   let accessToken: string | null = null;
   let refreshToken: string | null = null;
-  const refreshUser = insertableUserObject.parse({
+  const refreshUser = authenticatableUserObject.parse({
     email: 'refreshUser@votura.org',
     password: 'MyStrong!Password123',
-    role: 1,
   });
 
   beforeAll(async () => {
-    await createUser(refreshUser);
+    await createUser({ ...refreshUser, role: 1 });
     user = await findUserBy({ email: refreshUser.email });
     if (user === null) {
       throw new Error('Failed to find test user');

--- a/apps/backend/test/users/refreshUserTokens.test.ts
+++ b/apps/backend/test/users/refreshUserTokens.test.ts
@@ -27,6 +27,7 @@ describe(`POST /users/refreshTokens`, () => {
   const refreshUser = insertableUserObject.parse({
     email: 'refreshUser@votura.org',
     password: 'MyStrong!Password123',
+    role: 1,
   });
 
   beforeAll(async () => {

--- a/apps/backend/test/users/refreshUserTokens.test.ts
+++ b/apps/backend/test/users/refreshUserTokens.test.ts
@@ -30,7 +30,7 @@ describe(`POST /users/refreshTokens`, () => {
   });
 
   beforeAll(async () => {
-    await createUser({ ...refreshUser, role: 1 });
+    await createUser({ ...refreshUser, role: 'admin' });
     user = await findUserBy({ email: refreshUser.email });
     if (user === null) {
       throw new Error('Failed to find test user');

--- a/apps/docs/static/uml/dataModel.puml
+++ b/apps/docs/static/uml/dataModel.puml
@@ -15,6 +15,7 @@ entity "user" as user #006b75 {
     passwordResetTokenExpiresAt : TIMESTAMPTZ(6) | NULL
     refreshTokenHash : VARCHAR(64) | NULL
     refreshTokenExpiresAt : TIMESTAMPTZ(6) | NULL
+    * role : INTEGER
     --
 }
 

--- a/apps/docs/static/uml/dataModel.puml
+++ b/apps/docs/static/uml/dataModel.puml
@@ -15,9 +15,13 @@ entity "user" as user #006b75 {
     passwordResetTokenExpiresAt : TIMESTAMPTZ(6) | NULL
     refreshTokenHash : VARCHAR(64) | NULL
     refreshTokenExpiresAt : TIMESTAMPTZ(6) | NULL
-    * role : INTEGER
+    * role : VARCHAR
     --
 }
+
+note as N5
+The roles are "converted" to enums in JS
+end note
 
 entity "accessTokenBlacklist" as jwtBlacklist #006b75 {
     ' this table is used to store blacklisted access tokens
@@ -193,5 +197,6 @@ voterGroups "1"--"1..*" voters : contains >
 voters -- N3
 votes -- N4
 failedLoginAttempt "*"--"0..1" user : belongs to >
+user -- N5
 
 @enduml

--- a/apps/docs/static/uml/dataModel.puml
+++ b/apps/docs/static/uml/dataModel.puml
@@ -15,13 +15,9 @@ entity "user" as user #006b75 {
     passwordResetTokenExpiresAt : TIMESTAMPTZ(6) | NULL
     refreshTokenHash : VARCHAR(64) | NULL
     refreshTokenExpiresAt : TIMESTAMPTZ(6) | NULL
-    * role : VARCHAR
+    * role : ENUM("user", "admin")
     --
 }
-
-note as N5
-The roles are "converted" to enums in JS
-end note
 
 entity "accessTokenBlacklist" as jwtBlacklist #006b75 {
     ' this table is used to store blacklisted access tokens
@@ -197,6 +193,5 @@ voterGroups "1"--"1..*" voters : contains >
 voters -- N3
 votes -- N4
 failedLoginAttempt "*"--"0..1" user : belongs to >
-user -- N5
 
 @enduml

--- a/apps/frontend/src/components/views/login/LoginView.tsx
+++ b/apps/frontend/src/components/views/login/LoginView.tsx
@@ -15,7 +15,7 @@ import {
 import { useForm } from '@mantine/form';
 import { useToggle } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
-import { insertableUserObject } from '@repo/votura-validators';
+import { authenticatableUserObject } from '@repo/votura-validators';
 import axios from 'axios';
 import { type JSX, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -36,7 +36,7 @@ export const LoginView = (): JSX.Element => {
     },
     validate: {
       email: (value) => {
-        const parsed = insertableUserObject.shape.email.safeParse(value);
+        const parsed = authenticatableUserObject.shape.email.safeParse(value);
         return parsed.success ? null : t('invalidEmailAddress', 'Invalid email address.');
       },
     },

--- a/apps/frontend/src/components/views/login/RegisterView.tsx
+++ b/apps/frontend/src/components/views/login/RegisterView.tsx
@@ -10,7 +10,7 @@ import {
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { notifications } from '@mantine/notifications';
-import { insertableUserObject } from '@repo/votura-validators';
+import { authenticatableUserObject } from '@repo/votura-validators';
 import type { JSX } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
@@ -30,7 +30,7 @@ export const RegisterView = (): JSX.Element => {
     },
     validate: {
       email: (value) => {
-        const parsed = insertableUserObject.shape.email.safeParse(value);
+        const parsed = authenticatableUserObject.shape.email.safeParse(value);
         const userErrorMessage: string = t('invalidEmailAddress', 'Invalid email address.');
         if (!parsed.success) {
           return userErrorMessage;
@@ -38,7 +38,7 @@ export const RegisterView = (): JSX.Element => {
         return null;
       },
       password: (value) => {
-        const parsed = insertableUserObject.shape.password.safeParse(value);
+        const parsed = authenticatableUserObject.shape.password.safeParse(value);
         const userErrorMessage: string = t(
           'passwordDoesNotMeetRequirements',
           'Password does not meet requirements.',

--- a/apps/frontend/src/swr/useLoginUser.ts
+++ b/apps/frontend/src/swr/useLoginUser.ts
@@ -1,7 +1,7 @@
 import {
   type ApiTokenUser,
   apiTokenUserObject,
-  type InsertableUser,
+  type AuthenticatableUser,
 } from '@repo/votura-validators';
 import useSWRMutation, { type SWRMutationResponse } from 'swr/mutation';
 import { apiRoutes } from './apiRoutes.ts';
@@ -11,7 +11,7 @@ export const useLoginUser = (): SWRMutationResponse<
   ApiTokenUser,
   Error,
   string,
-  InsertableUser
+  AuthenticatableUser
 > => {
   return useSWRMutation(apiRoutes.users.login, posterFactory(apiTokenUserObject));
 };

--- a/apps/frontend/src/swr/useRegisterUser.ts
+++ b/apps/frontend/src/swr/useRegisterUser.ts
@@ -3,6 +3,11 @@ import useSWRMutation, { type SWRMutationResponse } from 'swr/mutation';
 import { apiRoutes } from './apiRoutes.ts';
 import { posterFactory } from './posterFactory.ts';
 
-export const useRegisterUser = (): SWRMutationResponse<void, Error, string, AuthenticatableUser> => {
+export const useRegisterUser = (): SWRMutationResponse<
+  void,
+  Error,
+  string,
+  AuthenticatableUser
+> => {
   return useSWRMutation(apiRoutes.users.base, posterFactory());
 };

--- a/apps/frontend/src/swr/useRegisterUser.ts
+++ b/apps/frontend/src/swr/useRegisterUser.ts
@@ -1,8 +1,8 @@
-import type { InsertableUser } from '@repo/votura-validators';
+import type { AuthenticatableUser } from '@repo/votura-validators';
 import useSWRMutation, { type SWRMutationResponse } from 'swr/mutation';
 import { apiRoutes } from './apiRoutes.ts';
 import { posterFactory } from './posterFactory.ts';
 
-export const useRegisterUser = (): SWRMutationResponse<void, Error, string, InsertableUser> => {
+export const useRegisterUser = (): SWRMutationResponse<void, Error, string, AuthenticatableUser> => {
   return useSWRMutation(apiRoutes.users.base, posterFactory());
 };

--- a/cspell.json
+++ b/cspell.json
@@ -95,6 +95,7 @@
     "docusaurus",
     "checkgroup",
     "usecase",
-    "taskkill"
+    "taskkill",
+    "userrole"
   ]
 }

--- a/packages/db/src/migrations/20260725_user_roles.ts
+++ b/packages/db/src/migrations/20260725_user_roles.ts
@@ -5,7 +5,7 @@ import { TableName, UserColumnName } from '../nameEnums.js';
 async function createRoleColumn(db: Kysely<any>): Promise<void> {
   await db.schema
     .alterTable(TableName.user)
-    .addColumn(UserColumnName.role, 'integer', (col) => col.notNull().defaultTo(0))
+    .addColumn(UserColumnName.role, 'varchar', (col) => col.notNull().defaultTo('user'))
     .execute();
 }
 

--- a/packages/db/src/migrations/20260725_user_roles.ts
+++ b/packages/db/src/migrations/20260725_user_roles.ts
@@ -1,12 +1,22 @@
-import type { Kysely } from 'kysely';
+import { type Kysely, sql } from 'kysely';
 import { TableName, UserColumnName } from '../nameEnums.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function createRoleType(db: Kysely<any>): Promise<void> {
+  await db.schema.createType('userrole').asEnum(['user', 'admin']).execute();
+}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function createRoleColumn(db: Kysely<any>): Promise<void> {
   await db.schema
     .alterTable(TableName.user)
-    .addColumn(UserColumnName.role, 'varchar', (col) => col.notNull().defaultTo('user'))
+    .addColumn(UserColumnName.role, sql`userrole`, (col) => col.notNull().defaultTo('user'))
     .execute();
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function dropRoleType(db: Kysely<any>): Promise<void> {
+  await db.schema.dropType('userrole').execute();
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -17,10 +27,12 @@ async function dropRoleColumn(db: Kysely<any>): Promise<void> {
 // --- Main Migration Functions ---
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function up(db: Kysely<any>): Promise<void> {
+  await createRoleType(db);
   await createRoleColumn(db);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function down(db: Kysely<any>): Promise<void> {
   await dropRoleColumn(db);
+  await dropRoleType(db);
 }

--- a/packages/db/src/migrations/20260725_user_roles.ts
+++ b/packages/db/src/migrations/20260725_user_roles.ts
@@ -1,0 +1,26 @@
+import type { Kysely } from 'kysely';
+import { TableName, UserColumnName } from '../nameEnums.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function createRoleColumn(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable(TableName.user)
+    .addColumn(UserColumnName.role, 'integer', (col) => col.notNull().defaultTo(0))
+    .execute();
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function dropRoleColumn(db: Kysely<any>): Promise<void> {
+  await db.schema.alterTable(TableName.user).dropColumn(UserColumnName.role).execute();
+}
+
+// --- Main Migration Functions ---
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function up(db: Kysely<any>): Promise<void> {
+  await createRoleColumn(db);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function down(db: Kysely<any>): Promise<void> {
+  await dropRoleColumn(db);
+}

--- a/packages/db/src/nameEnums.ts
+++ b/packages/db/src/nameEnums.ts
@@ -36,6 +36,7 @@ export enum UserColumnName {
   passwordResetTokenExpiresAt = 'passwordResetTokenExpiresAt',
   refreshTokenHash = 'refreshTokenHash',
   refreshTokenExpiresAt = 'refreshTokenExpiresAt',
+  role = 'role',
 }
 
 export enum AccessTokenBlacklistColumnName {

--- a/packages/db/src/types/db.d.ts
+++ b/packages/db/src/types/db.d.ts
@@ -28,6 +28,8 @@ export type Numeric = ColumnType<string, number | string, number | string>;
 
 export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
+export type Userrole = 'admin' | 'user';
+
 export interface AccessTokenBlacklist {
   accessTokenId: string;
   createdAt: Generated<Timestamp>;
@@ -140,7 +142,7 @@ export interface User {
   passwordResetTokenHash: string | null;
   refreshTokenExpiresAt: Timestamp | null;
   refreshTokenHash: string | null;
-  role: Generated<string>;
+  role: Generated<Userrole>;
   verified: Generated<boolean>;
 }
 

--- a/packages/db/src/types/db.d.ts
+++ b/packages/db/src/types/db.d.ts
@@ -3,12 +3,11 @@
  * Please do not edit it manually.
  */
 
-import type { ColumnType } from 'kysely';
+import type { ColumnType } from "kysely";
 
-export type Generated<T> =
-  T extends ColumnType<infer S, infer I, infer U>
-    ? ColumnType<S, I | undefined, U>
-    : ColumnType<T, T | undefined, T>;
+export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
+  ? ColumnType<S, I | undefined, U>
+  : ColumnType<T, T | undefined, T>;
 
 export type Int8 = ColumnType<string, bigint | number | string, bigint | number | string>;
 
@@ -139,6 +138,7 @@ export interface User {
   passwordResetTokenHash: string | null;
   refreshTokenExpiresAt: Timestamp | null;
   refreshTokenHash: string | null;
+  role: Generated<number>;
   verified: Generated<boolean>;
 }
 
@@ -183,8 +183,8 @@ export interface DB {
   ballotPaperSection: BallotPaperSection;
   ballotPaperSectionCandidate: BallotPaperSectionCandidate;
   candidate: Candidate;
-  'cron.job': CronJob;
-  'cron.job_run_details': CronJobRunDetails;
+  "cron.job": CronJob;
+  "cron.job_run_details": CronJobRunDetails;
   election: Election;
   failedLoginAttempt: FailedLoginAttempt;
   user: User;

--- a/packages/db/src/types/db.d.ts
+++ b/packages/db/src/types/db.d.ts
@@ -3,11 +3,12 @@
  * Please do not edit it manually.
  */
 
-import type { ColumnType } from "kysely";
+import type { ColumnType } from 'kysely';
 
-export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
-  ? ColumnType<S, I | undefined, U>
-  : ColumnType<T, T | undefined, T>;
+export type Generated<T> =
+  T extends ColumnType<infer S, infer I, infer U>
+    ? ColumnType<S, I | undefined, U>
+    : ColumnType<T, T | undefined, T>;
 
 export type Int8 = ColumnType<string, bigint | number | string, bigint | number | string>;
 
@@ -183,8 +184,8 @@ export interface DB {
   ballotPaperSection: BallotPaperSection;
   ballotPaperSectionCandidate: BallotPaperSectionCandidate;
   candidate: Candidate;
-  "cron.job": CronJob;
-  "cron.job_run_details": CronJobRunDetails;
+  'cron.job': CronJob;
+  'cron.job_run_details': CronJobRunDetails;
   election: Election;
   failedLoginAttempt: FailedLoginAttempt;
   user: User;

--- a/packages/db/src/types/db.d.ts
+++ b/packages/db/src/types/db.d.ts
@@ -139,7 +139,7 @@ export interface User {
   passwordResetTokenHash: string | null;
   refreshTokenExpiresAt: Timestamp | null;
   refreshTokenHash: string | null;
-  role: Generated<number>;
+  role: Generated<string>;
   verified: Generated<boolean>;
 }
 

--- a/packages/votura-validators/src/objects/user.ts
+++ b/packages/votura-validators/src/objects/user.ts
@@ -82,8 +82,10 @@ export const authenticatableUserObject = userObject.pick({ email: true, password
 
 export type AuthenticatableUser = z.infer<typeof authenticatableUserObject>;
 
-export const authenticatableUserObjectSchema = z.toJSONSchema(authenticatableUserObject, toJsonSchemaParams);
-
+export const authenticatableUserObjectSchema = z.toJSONSchema(
+  authenticatableUserObject,
+  toJsonSchemaParams,
+);
 
 export const apiTokenUserObject = userObject.pick({
   refreshToken: true,

--- a/packages/votura-validators/src/objects/user.ts
+++ b/packages/votura-validators/src/objects/user.ts
@@ -78,6 +78,13 @@ export type SelectableUser = z.infer<typeof selectableUserObject>;
 
 export const selectableUserObjectSchema = z.toJSONSchema(selectableUserObject, toJsonSchemaParams);
 
+export const authenticatableUserObject = userObject.pick({ email: true, password: true });
+
+export type AuthenticatableUser = z.infer<typeof authenticatableUserObject>;
+
+export const authenticatableUserObjectSchema = z.toJSONSchema(authenticatableUserObject, toJsonSchemaParams);
+
+
 export const apiTokenUserObject = userObject.pick({
   refreshToken: true,
   accessToken: true,

--- a/packages/votura-validators/src/objects/user.ts
+++ b/packages/votura-validators/src/objects/user.ts
@@ -52,9 +52,9 @@ export const userObject = z.object({
       example:
         'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.NHVaYe26MbtOYhSKkoKYdFVomg4i8ZJd8_-RU8VNbftc4TSMb4bXP3l3YlNWACwyXPGffz5aXHc6lty1Y2t4SWRqGteragsVdZufDn5BlnJl9pdR_kdVFUsra2rWKEofkZeIC4yWytE58sMIihvo9H1ScmmVwBcQP6XETqYd0aSHp1gOa9RdUPDvoXQ5oqygTqVtxaDr6wUFKrKItgBMzWIdNZ6y7O9E0DhEPTbE9rfBo6KTFsHAZnMg4k68CDp2woYIaXbmYTWcvbzIuHO7_37GT79XdIwkm95QJ7hYC9RiwrV7mesbY4PAahERJawntho0my942XheVLmGwLMBkQ',
     }),
-  role: z.int32().min(0).max(1).register(voturaMetadataRegistry, {
-    description: 'The role of the user. 0 stands for normal users, 1 for administrators.',
-    example: '0',
+  role: z.enum(['user', 'admin']).register(voturaMetadataRegistry, {
+    description: 'The role and access level of the user.',
+    example: 'user',
   }),
 });
 

--- a/packages/votura-validators/src/objects/user.ts
+++ b/packages/votura-validators/src/objects/user.ts
@@ -52,11 +52,15 @@ export const userObject = z.object({
       example:
         'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.NHVaYe26MbtOYhSKkoKYdFVomg4i8ZJd8_-RU8VNbftc4TSMb4bXP3l3YlNWACwyXPGffz5aXHc6lty1Y2t4SWRqGteragsVdZufDn5BlnJl9pdR_kdVFUsra2rWKEofkZeIC4yWytE58sMIihvo9H1ScmmVwBcQP6XETqYd0aSHp1gOa9RdUPDvoXQ5oqygTqVtxaDr6wUFKrKItgBMzWIdNZ6y7O9E0DhEPTbE9rfBo6KTFsHAZnMg4k68CDp2woYIaXbmYTWcvbzIuHO7_37GT79XdIwkm95QJ7hYC9RiwrV7mesbY4PAahERJawntho0my942XheVLmGwLMBkQ',
     }),
+  role: z.int32().min(0).max(1).register(voturaMetadataRegistry, {
+    description: 'The role of the user. 0 stands for normal users, 1 for administrators.',
+    example: '0',
+  }),
 });
 
 export type User = z.infer<typeof userObject>;
 
-export const insertableUserObject = userObject.pick({ email: true, password: true });
+export const insertableUserObject = userObject.pick({ email: true, password: true, role: true });
 
 export type InsertableUser = z.infer<typeof insertableUserObject>;
 
@@ -67,6 +71,7 @@ export const selectableUserObject = userObject.pick({
   createdAt: true,
   modifiedAt: true,
   email: true,
+  role: true,
 });
 
 export type SelectableUser = z.infer<typeof selectableUserObject>;

--- a/packages/votura-validators/src/schema/users/loginPathObject.ts
+++ b/packages/votura-validators/src/schema/users/loginPathObject.ts
@@ -1,5 +1,5 @@
 import type { OpenAPIV3 } from 'openapi-types';
-import { apiTokenUserObjectSchema, insertableUserObjectSchema } from '../../objects/user.js';
+import { apiTokenUserObjectSchema, authenticatableUserObjectSchema } from '../../objects/user.js';
 import {
   response400,
   response401,
@@ -24,7 +24,7 @@ export const loginPathObject: OpenAPIV3.PathItemObject = {
       content: {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         'application/json': {
-          schema: insertableUserObjectSchema as OpenAPIV3.SchemaObject,
+          schema: authenticatableUserObjectSchema as OpenAPIV3.SchemaObject,
         },
       },
     },

--- a/packages/votura-validators/src/schema/users/usersPathObject.ts
+++ b/packages/votura-validators/src/schema/users/usersPathObject.ts
@@ -1,5 +1,5 @@
 import type { OpenAPIV3 } from 'openapi-types';
-import { insertableUserObjectSchema } from '../../objects/user.js';
+import { authenticatableUserObjectSchema } from '../../objects/user.js';
 import {
   response400,
   response401,
@@ -26,7 +26,7 @@ export const usersPathObject: OpenAPIV3.PathItemObject = {
       content: {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         'application/json': {
-          schema: insertableUserObjectSchema as OpenAPIV3.SchemaObject,
+          schema: authenticatableUserObjectSchema as OpenAPIV3.SchemaObject,
         },
       },
     },


### PR DESCRIPTION
# Changes

Resolves #456 

- Adds DB column "role" on users table
- Adds "role" field to DB PUML overview
- Expose "role" field on SelectableUser and InsertableUser objects so that they will be editable through the REST API
- Create zod validator for authentication credentials, which only contain email and password, but not the role (old InsertableUser)