### PR TITLE
Rework own account section in page layout

### DIFF
--- a/apps/frontend/src/components/AppShellLayout.tsx
+++ b/apps/frontend/src/components/AppShellLayout.tsx
@@ -1,5 +1,5 @@
-import { AppShell, Box, Button, Divider, Space, Stack } from '@mantine/core';
-import { IconNotes, IconUsersGroup } from '@tabler/icons-react';
+import { ActionIcon, AppShell, Avatar, Box, Divider, Flex, Space, Stack } from '@mantine/core';
+import { IconLogout, IconNotes, IconUsersGroup } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useNavigate } from 'react-router';
@@ -19,7 +19,7 @@ export const AppShellLayout = (): JSX.Element => {
   return (
     <AppShell
       navbar={{
-        width: 300,
+        width: 350,
         breakpoint: 'sm',
       }}
     >
@@ -42,9 +42,17 @@ export const AppShellLayout = (): JSX.Element => {
           </Box>
           <Box>
             <Divider pb={'md'} />
-            <Button variant="subtle" fullWidth onClick={onLogout}>
-              {t('logout', 'Logout')}
-            </Button>
+            <Flex justify={'space-between'} align={'center'} gap={'sm'}>
+              <RoutingNavbarLink
+                to={'/account'}
+                label={'your.name@uni-ulm.de'}
+                icon={<Avatar />}
+              />
+
+              <ActionIcon variant="subtle" aria-label={t('logout', 'Logout')} onClick={onLogout}>
+                <IconLogout size={24} />
+              </ActionIcon>
+            </Flex>
           </Box>
         </Stack>
       </AppShell.Navbar>

--- a/apps/frontend/src/components/AppShellLayout.tsx
+++ b/apps/frontend/src/components/AppShellLayout.tsx
@@ -1,9 +1,10 @@
-import { ActionIcon, AppShell, Avatar, Box, Divider, Flex, Space, Stack } from '@mantine/core';
+import { ActionIcon, AppShell, Box, Divider, Flex, Space, Stack } from '@mantine/core';
 import { IconLogout, IconNotes, IconUsersGroup } from '@tabler/icons-react';
 import type { JSX } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useNavigate } from 'react-router';
 import { clearAuthLocalStorage } from '../swr/authTokens.ts';
+import { Avatar } from './Avatar.tsx';
 import { NavbarHeader } from './navbar/NavbarHeader.tsx';
 import { RoutingNavbarLink } from './navbar/RoutingNavbarLink.tsx';
 
@@ -46,7 +47,7 @@ export const AppShellLayout = (): JSX.Element => {
               <RoutingNavbarLink
                 to={'/account'}
                 label={'your.name@uni-ulm.de'}
-                icon={<Avatar />}
+                icon={<Avatar userId={''} email={'your.name@uni-ulm.de'} />}
               />
 
               <ActionIcon variant="subtle" aria-label={t('logout', 'Logout')} onClick={onLogout}>

--- a/apps/frontend/src/components/Avatar.tsx
+++ b/apps/frontend/src/components/Avatar.tsx
@@ -1,5 +1,5 @@
 import { Avatar as MantineAvatar } from '@mantine/core';
-import { type JSX } from 'react';
+import type { JSX } from 'react';
 import { renderToString } from 'react-dom/server';
 
 export interface AvatarProps {
@@ -27,11 +27,13 @@ const determineInitials = (email: string): string => {
     for (let i = 0; i < username.length; i++) {
       const char = username.charAt(i);
 
+      // Skip if the char is a separator
       if (separators.includes(char)) {
         separated = true;
         continue;
       }
 
+      // If the char is separated from the previous one, add it to the avatar preview
       if (separated) {
         initials += char.toUpperCase();
       }
@@ -81,7 +83,7 @@ const PrivateAvatar = ({ userId, email }: AvatarProps): JSX.Element => {
 
 export const Avatar = ({ userId, email }: AvatarProps): JSX.Element => {
   const privateAvatarSvg = renderToString(<PrivateAvatar userId={userId} email={email} />);
-  const avatarSrc = 'data:image/svg+xml;base64,' + btoa(privateAvatarSvg);
+  const avatarSrc = 'data:image/svg+xml,' + encodeURIComponent(privateAvatarSvg);
 
   return <MantineAvatar src={avatarSrc} />;
 };

--- a/apps/frontend/src/components/Avatar.tsx
+++ b/apps/frontend/src/components/Avatar.tsx
@@ -85,5 +85,5 @@ export const Avatar = ({ userId, email }: AvatarProps): JSX.Element => {
   const privateAvatarSvg = renderToString(<PrivateAvatar userId={userId} email={email} />);
   const avatarSrc = 'data:image/svg+xml,' + encodeURIComponent(privateAvatarSvg);
 
-  return <MantineAvatar src={avatarSrc} />;
+  return <MantineAvatar src={avatarSrc} alt={email} />;
 };

--- a/apps/frontend/src/components/Avatar.tsx
+++ b/apps/frontend/src/components/Avatar.tsx
@@ -1,5 +1,5 @@
 import { Avatar as MantineAvatar } from '@mantine/core';
-import { type JSX, useId } from 'react';
+import { type JSX } from 'react';
 import { renderToString } from 'react-dom/server';
 
 export interface AvatarProps {
@@ -47,8 +47,6 @@ const determineInitials = (email: string): string => {
 };
 
 const PrivateAvatar = ({ userId, email }: AvatarProps): JSX.Element => {
-  const componentId = useId(); // Unique component ID
-
   // Select random color pair based on userId hash
   const colorPair =
     colorPairs[
@@ -59,13 +57,13 @@ const PrivateAvatar = ({ userId, email }: AvatarProps): JSX.Element => {
   return (
     <svg xmlns={'http://www.w3.org/2000/svg'} viewBox={'0 0 128 128'}>
       <defs>
-        <linearGradient id={'avatar-gradient-' + componentId} x1={0} y1={1} x2={1} y2={0}>
+        <linearGradient id={'avatar-gradient'} x1={0} y1={1} x2={1} y2={0}>
           <stop offset={'0%'} style={{ stopColor: colorPair[0] }} />
           <stop offset={'100%'} style={{ stopColor: colorPair[1] }} />
         </linearGradient>
       </defs>
 
-      <rect width={'100%'} height={'100%'} fill={'url(#avatar-gradient-' + componentId + ')'} />
+      <rect width={'100%'} height={'100%'} fill={'url(#avatar-gradient)'} />
       <text
         x={'50%'}
         y={'50%'}

--- a/apps/frontend/src/components/Avatar.tsx
+++ b/apps/frontend/src/components/Avatar.tsx
@@ -1,9 +1,10 @@
+import { Avatar as MantineAvatar } from '@mantine/core';
 import { type JSX, useId } from 'react';
+import { renderToString } from 'react-dom/server';
 
 export interface AvatarProps {
   userId: string;
   email: string;
-  className: string | null;
 }
 
 const colorPairs = [
@@ -45,7 +46,7 @@ const determineInitials = (email: string): string => {
   return initials;
 };
 
-export const Avatar = ({ userId, email, className }: AvatarProps): JSX.Element => {
+const PrivateAvatar = ({ userId, email }: AvatarProps): JSX.Element => {
   const componentId = useId(); // Unique component ID
 
   // Select random color pair based on userId hash
@@ -56,7 +57,7 @@ export const Avatar = ({ userId, email, className }: AvatarProps): JSX.Element =
     ];
 
   return (
-    <svg xmlns={'http://www.w3.org/2000/svg'} viewBox={'0 0 128 128'} className={className ?? ''}>
+    <svg xmlns={'http://www.w3.org/2000/svg'} viewBox={'0 0 128 128'}>
       <defs>
         <linearGradient id={'avatar-gradient-' + componentId} x1={0} y1={1} x2={1} y2={0}>
           <stop offset={'0%'} style={{ stopColor: colorPair[0] }} />
@@ -69,12 +70,20 @@ export const Avatar = ({ userId, email, className }: AvatarProps): JSX.Element =
         x={'50%'}
         y={'50%'}
         fontSize={64}
+        fontFamily={'sans-serif'}
         fill={'white'}
         textAnchor={'middle'}
-        dominantBaseline={'middle'}
+        dominantBaseline={'central'}
       >
         {determineInitials(email)}
       </text>
     </svg>
   );
+};
+
+export const Avatar = ({ userId, email }: AvatarProps): JSX.Element => {
+  const privateAvatarSvg = renderToString(<PrivateAvatar userId={userId} email={email} />);
+  const avatarSrc = 'data:image/svg+xml;base64,' + btoa(privateAvatarSvg);
+
+  return <MantineAvatar src={avatarSrc} />;
 };


### PR DESCRIPTION
# Changes

Resolves #497 

- Updates the design of the own account section in the sidebar

<img width="352" height="915" alt="grafik" src="https://github.com/user-attachments/assets/30214718-4d2e-4987-9f7a-7b6fd91831e3" />

(It's intentionally hardcoded to your.name@uni-ulm.de at the moment because I'm still waiting for approval on #510. The final integration will take place for issue #498.)