### PR TITLE
API endpoint to retrieve information of all accounts

### DIFF
--- a/apps/backend/src/controllers/users/getUsers.uc.ts
+++ b/apps/backend/src/controllers/users/getUsers.uc.ts
@@ -1,3 +1,8 @@
-export const getUsers = async (): Promise<void> => {
-  // TODO #503: https://github.com/SE-UUlm/votura/issues/503
+import type { SelectableUser } from '@repo/votura-validators';
+import type { Request, Response } from 'express';
+import { getAllUsers } from '../../services/users.service.js';
+
+export const getUsers = async (_req: Request, res: Response<SelectableUser[]>): Promise<void> => {
+  const users = await getAllUsers();
+  res.status(200).json(users);
 };

--- a/apps/backend/src/services/users.service.ts
+++ b/apps/backend/src/services/users.service.ts
@@ -9,6 +9,17 @@ import type { Selectable } from 'kysely';
 import type { AccessTokenPayload } from '../auth/types.js';
 import { generateUserTokens, getTokenExpiration, hashRefreshToken } from '../auth/utils.js';
 
+const dbUserToSelectableUser = (user: Selectable<DBUser>): SelectableUser => {
+  return {
+    id: user.id,
+    createdAt: user.createdAt.toISOString(),
+    modifiedAt: user.modifiedAt.toISOString(),
+    email: user.email,
+    role: user.role,
+    active: user.active,
+  };
+};
+
 export async function findDBUserBy(
   criteria: Partial<Pick<User, 'id' | 'email'>>,
 ): Promise<Selectable<DBUser> | null> {
@@ -42,15 +53,7 @@ export async function findUserBy(
     return null;
   }
 
-  // Convert DBUser to SelectableUser
-  return {
-    id: user.id,
-    createdAt: user.createdAt.toISOString(),
-    modifiedAt: user.modifiedAt.toISOString(),
-    email: user.email,
-    role: user.role,
-    active: user.active,
-  };
+  return dbUserToSelectableUser(user);
 }
 
 export async function createUser(insertableUser: InsertableUser): Promise<void> {
@@ -161,4 +164,9 @@ export const userCount = async (): Promise<number> => {
     .executeTakeFirst();
 
   return Number(userCountResponse?.count ?? 0);
+};
+
+export const getAllUsers = async (): Promise<SelectableUser[]> => {
+  const allDbUsers = await db.selectFrom('user').selectAll().execute();
+  return allDbUsers.map(dbUserToSelectableUser);
 };

--- a/apps/backend/test/users/getUsers.test.ts
+++ b/apps/backend/test/users/getUsers.test.ts
@@ -1,0 +1,53 @@
+import { selectableUserObject, type ApiTokenUser } from '@repo/votura-validators';
+import request from 'supertest';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { app } from '../../src/app.js';
+import { generateUserTokens } from '../../src/auth/utils.js';
+import { HttpStatusCode } from '../../src/httpStatusCode.js';
+import { createUser, findUserBy } from '../../src/services/users.service.js';
+import { demoUser, demoUser2 } from '../mockData.js';
+
+describe(`GET /users`, () => {
+  const requestPath = '/users';
+  let tokens: ApiTokenUser = { accessToken: '', refreshToken: '' };
+
+  beforeAll(async () => {
+    await createUser(demoUser);
+    const user = await findUserBy({ email: demoUser.email });
+    if (user === null) {
+      throw new Error('Failed to find test user');
+    }
+
+    tokens = generateUserTokens(user.id);
+  });
+
+  it('200: should return the single user who is in the database', async () => {
+    const res = await request(app)
+      .get(requestPath)
+      .set('Authorization', `Bearer ${tokens.accessToken}`);
+
+    expect(res.status).toBe(HttpStatusCode.ok);
+    expect(res.type).toBe('application/json');
+    const parseResult = selectableUserObject.array().safeParse(res.body);
+    expect(parseResult.success).toBe(true);
+    if (parseResult.success) {
+      expect(parseResult.data.length).toBe(1);
+      expect(parseResult.data[0]?.email).toBe(demoUser.email);
+    }
+  });
+
+  it('200: should return more users when a new one is created', async () => {
+    await createUser(demoUser2);
+
+    const res = await request(app)
+      .get(requestPath)
+      .set('Authorization', `Bearer ${tokens.accessToken}`);
+
+    expect(res.status).toBe(HttpStatusCode.ok);
+    expect(res.type).toBe('application/json');
+    const parseResult = selectableUserObject.array().safeParse(res.body);
+    if (parseResult.success) {
+      expect(parseResult.data.length).toBe(2);
+    }
+  });
+});

--- a/packages/votura-validators/src/objects/user.ts
+++ b/packages/votura-validators/src/objects/user.ts
@@ -88,6 +88,10 @@ export const selectableUserObject = userObject.pick({
 export type SelectableUser = z.infer<typeof selectableUserObject>;
 
 export const selectableUserObjectSchema = z.toJSONSchema(selectableUserObject, toJsonSchemaParams);
+export const selectableUsersObjectSchema = z.toJSONSchema(
+  selectableUserObject.array(),
+  toJsonSchemaParams,
+);
 
 export const authenticatableUserObject = userObject.pick({ email: true, password: true });
 

--- a/packages/votura-validators/src/schema/users/usersPathObject.ts
+++ b/packages/votura-validators/src/schema/users/usersPathObject.ts
@@ -1,5 +1,8 @@
 import type { OpenAPIV3 } from 'openapi-types';
-import { authenticatableUserObjectSchema, selectableUserObjectSchema } from '../../objects/user.js';
+import {
+  authenticatableUserObjectSchema,
+  selectableUsersObjectSchema,
+} from '../../objects/user.js';
 import {
   response400,
   response401,
@@ -55,7 +58,7 @@ export const usersPathObject: OpenAPIV3.PathItemObject = {
     security: [
       { [SecuritySchemaName.voturaBackendAuth]: [], [SecuritySchemaName.voturaOnlyAdmin]: [] },
     ],
-    operationId: 'getUser',
+    operationId: 'getUsers',
     responses: {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       200: {
@@ -64,7 +67,7 @@ export const usersPathObject: OpenAPIV3.PathItemObject = {
         content: {
           // eslint-disable-next-line @typescript-eslint/naming-convention
           'application/json': {
-            schema: selectableUserObjectSchema as OpenAPIV3.SchemaObject,
+            schema: selectableUsersObjectSchema as OpenAPIV3.SchemaObject,
           },
         },
       },


### PR DESCRIPTION
> [!CAUTION]
> ### This PR is blocked by #532 

# Changes

Resolves #503 

- Adds a method in the User Service to convert `DBUser` objects to `SelectableUser` objects
- Adds a method in the User Service to get all users
- Implements the use-case to get all users by calling the new `getAllUsers` method in the User Service
- Modifies the OpenAPI schema as the `GET /users` endpoint now returns an array of `SelectableUser` objects
- Adds tests for the new API endpoint
